### PR TITLE
lock the container version

### DIFF
--- a/tests/todo-app.tests.integration/TodoApiFactory.cs
+++ b/tests/todo-app.tests.integration/TodoApiFactory.cs
@@ -22,7 +22,7 @@ public class TodoApiFactory : WebApplicationFactory<ITodoAppMarker>, IAsyncLifet
 
     private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder()
         .WithPassword(SaPassword)
-        .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        .WithImage("mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04")
         .WithEnvironment("ACCEPT_EULA", "Y")
         .WithEnvironment("MSSQL_PID", "Developer")
         .Build();


### PR DESCRIPTION
the latest 2022 container for MS SQL Server has some tooling changes that are not yet implemented in testcontainers. This PR locks the container version to a compatible version.