### PR TITLE
dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,63 @@
 version: 2
+
+registries:
+  public-nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+
 updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "01:00"
-      timezone: "America/Denver"
+      interval: "daily"
     commit-message:
       prefix: "GitHub Actions"
       include: "scope"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "01:00"
-      timezone: "America/Denver"
+      interval: "daily"
+    registries:
+      - public-nuget
+    groups:
+      contracts:
+        patterns:
+          - "src/todo-app.contracts/*"
+      core:
+        patterns:
+          - "src/todo-app.core/*"
+      server:
+        patterns:
+          - "src/todo-app.server/*"
+      tests:
+        patterns:
+          - "tests/todo-app.tests.integration/*"
     commit-message:
       prefix: "NuGet"
       include: "scope"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "npm"
     directory: "/src/todo-app.client"
     schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "01:00"
-      timezone: "America/Denver"
+      interval: "daily"
+    groups:
+      dependencies:
+        patterns:
+          - "dependencies/*"
+      dev-dependencies:
+        patterns:
+          - "devDependencies/*"
     commit-message:
       prefix: "npm"
       include: "scope"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
Update `dependabot.yml` to be more efficient and to check for dependencies daily.

- NuGet, npm, and GitHub Actions updates included
- Daily updates for all dependencies
- PR limit set to 15 for each package-ecosystem
- Grouped dependencies (NuGet projects, npm dependencies & devDependencies)
- Consistent commit message prefixes (NuGet, npm, GitHub Actions)
- labels: ["dependencies"] for easy filtering
- Optimized directory paths and patterns for efficiency
- Added the public-nuget registry for NuGet dependencies

closes #252 